### PR TITLE
Fixed "undefined symbol: pam_get_item" error with sudo 1.8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ CC		:= gcc
 CFLAGS		:= $(CFLAGS) -Wall -fPIC `pkg-config --cflags libxml-2.0` \
 	`pkg-config --cflags dbus-1`
 LIBS		:= `pkg-config --libs libxml-2.0` \
-	`pkg-config --libs dbus-1`
+	`pkg-config --libs dbus-1` -lpam
 
 # common source files
 SRCS		:= src/conf.c \


### PR DESCRIPTION
pam_usb was not linked with -lpam
