### PR TITLE
gnome-screensaver-command Gnome 3 update

### DIFF
--- a/doc/pamusb.conf
+++ b/doc/pamusb.conf
@@ -40,8 +40,8 @@ See http://www.pamusb.org/doc/configuring
 			<user id="scox">
 				<device>MyDevice</device>
 				<option name="quiet">true</option>
-				<agent event="lock">gnome-screensaver-command -lock</agent>
-				<agent event="unlock">gnome-screensaver-command -deactivate</agent>
+				<agent event="lock">gnome-screensaver-command --lock</agent>
+				<agent event="unlock">gnome-screensaver-command --deactivate</agent>
 			</user>
 
 			Configure user root to authenticate using MyDevice, but update one


### PR DESCRIPTION
Lock/Unlock would not work because of missing second "-" on the sample config.
