### PR TITLE
Changes to support compiling under osx

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ OBJS		:= $(SRCS:.c=.o)
 PAM_USB_SRCS	:= src/pam.c
 PAM_USB_OBJS	:= $(PAM_USB_SRCS:.c=.o)
 PAM_USB			:= pam_usb.so
-PAM_USB_LDFLAGS	:= -shared
+PAM_USB_LDFLAGS	:= -shared -lpam
 PAM_USB_DEST	:= $(DESTDIR)/$(LIBDIR)/security
 
 # pamusb-check

--- a/src/pam.c
+++ b/src/pam.c
@@ -17,7 +17,12 @@
 
 #define PAM_SM_AUTH
 #include <security/pam_modules.h>
-#include <security/_pam_macros.h>
+#ifndef __APPLE__
+#  include <security/_pam_macros.h>
+#else
+#  include <security/pam_appl.h>
+#  include <string.h> //strcmp
+#endif
 
 #include "version.h"
 #include "conf.h"

--- a/src/xpath.h
+++ b/src/xpath.h
@@ -18,6 +18,7 @@
 #ifndef PUSB_XPATH_H_
 # define PUSB_XPATH_H_
 # include <libxml/parser.h>
+# include <time.h>
 
 int pusb_xpath_get_string(xmlDocPtr doc, const char *path, char *value, size_t size);
 int pusb_xpath_get_string_from(xmlDocPtr doc, const char *base, const char *path, char *value, size_t size);


### PR DESCRIPTION
There are a few reasons that this won't compile under mac osx.  Namely, some things like time.h need to be included to get at time_t, and utmp stuff has changed.  In particular with the utmp stuff, on osx and freebsd, we don't have ut_addr_v6 in the utmp struct.

Although the changes here will allow this to compile, I have not tested that it will allow running correctly.
