### PR TITLE
Fixed typographical error, changed accross to across in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Features
 * `Non-intrusive.` pam\_usb doesn't require any modifications of the USB storage device to work (no additional partitions required).
 * USB Serial number, model and vendor verification.
 * Support for **One Time Pads** authentication.
-* You can use the same device accross multiple machines.
+* You can use the same device across multiple machines.
 * Support for all kind of removable devices (SD, MMC, etc).
 
 Tools


### PR DESCRIPTION
@aluzzardi, I've corrected a typographical error in the documentation of the [pam_usb](https://github.com/aluzzardi/pam_usb) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.