### PR TITLE
tools/pamusb-conf: tighten --add-device logic

### DIFF
--- a/tools/pamusb-conf
+++ b/tools/pamusb-conf
@@ -187,6 +187,16 @@ def addDevice(options):
 		sys.exit(1)
 
 	devs = doc.getElementsByTagName('devices')
+
+	# Check that the id of the device to add is not already present in the configFile
+	for devices in devs:
+		for device in devices.getElementsByTagName("device"):
+			if device.getAttribute("id") == options['deviceName']:
+				msg =  [ '\nWARNING: A device node already exits for new device \'%s\'.',
+						 '\nTo proceed re-run --add-device using a different name or remove the existing entry in %s.' ]
+				print '\n'.join(msg) % (options['deviceName'], options['configFile'])
+				sys.exit(2)
+
 	dev = doc.createElement('device')
 	dev.attributes['id'] = options['deviceName']
 


### PR DESCRIPTION
Prevent pamusb-conf from creating a new device when that new device
collides with an existing node in the pam_usb configuration file.

---

Hit issue #14 and, after fixing per the comments, dug into the source and noticed that pamusb-conf will happily add colliding entries with ``--add-device=<name>``. This patch prevents those collisions from happening.